### PR TITLE
Add -s/--single option to make_results

### DIFF
--- a/src/vivarium_csu_swissre_cervical_cancer/results_processing/process_results.py
+++ b/src/vivarium_csu_swissre_cervical_cancer/results_processing/process_results.py
@@ -59,7 +59,7 @@ class MeasureData(NamedTuple):
             df.to_csv(output_dir / f'{key}.csv')
 
 
-def read_data(path: Path) -> (pd.DataFrame, List[str]):
+def read_data(path: Path, single_run: bool) -> (pd.DataFrame, List[str]):
     data = pd.read_hdf(path)
     # noinspection PyUnresolvedReferences
     data = (data
@@ -67,10 +67,18 @@ def read_data(path: Path) -> (pd.DataFrame, List[str]):
             .reset_index(drop=True)
             .rename(columns={results.OUTPUT_SCENARIO_COLUMN: SCENARIO_COLUMN})
             )
-    data[results.INPUT_DRAW_COLUMN] = data[results.INPUT_DRAW_COLUMN].astype(int)
-    data[results.RANDOM_SEED_COLUMN] = data[results.RANDOM_SEED_COLUMN].astype(int)
-    with (path.parent / 'keyspace.yaml').open() as f:
-        keyspace = yaml.full_load(f)
+    if single_run:
+        data[results.INPUT_DRAW_COLUMN] = 0
+        data[results.RANDOM_SEED_COLUMN] = 0
+        data['scenario'] = 'baseline'
+        keyspace = {results.INPUT_DRAW_COLUMN: [0],
+                    results.RANDOM_SEED_COLUMN: [0],
+                    'screening_algorithm.scenario': ['baseline']}
+    else:
+        data[results.INPUT_DRAW_COLUMN] = data[results.INPUT_DRAW_COLUMN].astype(int)
+        data[results.RANDOM_SEED_COLUMN] = data[results.RANDOM_SEED_COLUMN].astype(int)
+        with (path.parent / 'keyspace.yaml').open() as f:
+            keyspace = yaml.full_load(f)
     return data, keyspace
 
 

--- a/src/vivarium_csu_swissre_cervical_cancer/tools/cli.py
+++ b/src/vivarium_csu_swissre_cervical_cancer/tools/cli.py
@@ -97,7 +97,11 @@ def make_artifacts(location: str, output_dir: str, append: bool, verbose: int, w
 @click.option('--pdb', 'with_debugger',
               is_flag=True,
               help='Drop into python debugger if an error occurs.')
-def make_results(output_file: str, verbose: int, with_debugger: bool) -> None:
+@click.option('-s', '--single', 'single_run',
+              default=False,
+              is_flag=True,
+              help='Results are from a single, non-parallel run.')
+def make_results(output_file: str, verbose: int, with_debugger: bool, single_run: bool) -> None:
     configure_logging_to_terminal(verbose)
     main = handle_exceptions(build_results, logger, with_debugger=with_debugger)
-    main(output_file)
+    main(output_file, single_run)

--- a/src/vivarium_csu_swissre_cervical_cancer/tools/make_results.py
+++ b/src/vivarium_csu_swissre_cervical_cancer/tools/make_results.py
@@ -6,7 +6,7 @@ from loguru import logger
 from vivarium_csu_swissre_cervical_cancer.results_processing import process_results
 
 
-def build_results(output_file: str):
+def build_results(output_file: str, single_run: bool):
     output_file = Path(output_file)
     measure_dir = output_file.parent / 'count_data'
     if measure_dir.exists():
@@ -14,7 +14,7 @@ def build_results(output_file: str):
     measure_dir.mkdir(exist_ok=True, mode=0o775)
 
     logger.info(f'Reading in output data from {str(output_file)}.')
-    data, keyspace = process_results.read_data(output_file)
+    data, keyspace = process_results.read_data(output_file, single_run)
     logger.info(f'Filtering incomplete data from outputs.')
     rows = len(data)
     data = process_results.filter_out_incomplete(data, keyspace)


### PR DESCRIPTION
Adds a -s/--single option to run make_results on output.hdf files
not produced via psimulate (e.g., single `simulate` runs)

Tested with output.hdfs from cervical cancer.