### PR TITLE
MIC-2049: Update no-hpv-vaccination risk distribution

### DIFF
--- a/src/vivarium_csu_swissre_cervical_cancer/model_specifications/model_spec.in
+++ b/src/vivarium_csu_swissre_cervical_cancer/model_specifications/model_spec.in
@@ -53,8 +53,8 @@ configuration:
 
     effect_of_no_hpv_vaccination_on_high_risk_hpv:
         incidence_rate:
-            mean: 4.5454
-            se: 0.81
+            mean: 4.71
+            se: 0.94
 
     metrics:
         disability:


### PR DESCRIPTION
Updates for RT guidance on risk distribution: Use normal distribution normal(mean=4.71, SD=0.94) for relative risk of incident HPV 16/18 infection for unvaccinated versus vaccinated group