### PR TITLE
MIC-2189: Add and use LogNormalRiskEffect for treatment risk effect

### DIFF
--- a/src/vivarium_csu_swissre_cervical_cancer/components/__init__.py
+++ b/src/vivarium_csu_swissre_cervical_cancer/components/__init__.py
@@ -1,11 +1,12 @@
 from vivarium_csu_swissre_cervical_cancer.components.disease import CervicalCancer
+from vivarium_csu_swissre_cervical_cancer.components.hpvvaccineexposure import HpvVaccineExposure
+from vivarium_csu_swissre_cervical_cancer.components.intervention import Intervention
 from vivarium_csu_swissre_cervical_cancer.components.observers import (MortalityObserver,
                                                                        DisabilityObserver,
                                                                        StateMachineObserver,
                                                                        ScreeningObserver,
                                                                        VaccinationObserver,
                                                                        TreatmentObserver)
+from vivarium_csu_swissre_cervical_cancer.components.risk_effect import LogNormalRiskEffect
 from vivarium_csu_swissre_cervical_cancer.components.screening import ScreeningAlgorithm
-from vivarium_csu_swissre_cervical_cancer.components.intervention import Intervention
-from vivarium_csu_swissre_cervical_cancer.components.hpvvaccineexposure import HpvVaccineExposure
 from vivarium_csu_swissre_cervical_cancer.components.treatment import TreatmentExposure

--- a/src/vivarium_csu_swissre_cervical_cancer/components/risk_effect.py
+++ b/src/vivarium_csu_swissre_cervical_cancer/components/risk_effect.py
@@ -1,0 +1,61 @@
+import numpy as np
+# import pandas as pd
+import typing
+
+# from vivarium.framework.randomness import RandomnessStream
+from vivarium_public_health.risks.data_transformations import (generate_relative_risk_from_distribution,
+                                                               get_exposure_data,
+                                                               get_relative_risk_data,
+                                                               pivot_categorical,
+                                                               rebin_relative_risk_data)
+from vivarium_public_health.risks.effect import RiskEffect
+# from vivarium_public_health.utilities import EntityString, TargetString
+
+if typing.TYPE_CHECKING:
+    from vivarium.framework.engine import Builder
+
+
+class LogNormalRiskEffect(RiskEffect):
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: 'Builder'):
+        self.validate_config(builder)
+
+        relative_risk_data = self.load_relative_risk_data(builder)
+        self.relative_risk = builder.lookup.build_table(relative_risk_data, key_columns=['sex'],
+                                                        parameter_columns=['age', 'year'])
+        population_attributable_fraction_data = self.load_population_attributable_fraction_data(builder)
+        self.population_attributable_fraction = builder.lookup.build_table(population_attributable_fraction_data,
+                                                                           key_columns=['sex'],
+                                                                           parameter_columns=['age', 'year'])
+        self.exposure_effect = self.load_exposure_effect(builder)
+
+        builder.value.register_value_modifier(f'{self.target.name}.{self.target.measure}',
+                                              modifier=self.adjust_target,
+                                              requires_values=[f'{self.risk.name}.exposure'],
+                                              requires_columns=['age', 'sex'])
+        builder.value.register_value_modifier(f'{self.target.name}.{self.target.measure}.paf',
+                                              modifier=self.population_attributable_fraction,
+                                              requires_columns=['age', 'sex'])
+
+    def validate_config(self, builder: 'Builder'):
+        source_key = f'effect_of_{self.risk.name}_on_{self.target.name}'
+        relative_risk_source = builder.configuration[source_key][self.target.measure]
+        provided_keys = set(k for k, v in relative_risk_source.to_dict().items() if isinstance(v, (int, float)))
+        if provided_keys != {"mean", "se"}:
+            raise ValueError(f'The acceptable parameter options for specifying relative risk are: '
+                             f'{{"mean", "se"}}. You provided {provided_keys} for {source_key}.')
+
+    def load_relative_risk_data(self, builder: 'Builder'):
+        rr_data = get_relative_risk_data(builder, self.risk, self.target)
+        rr_data.loc[:, 'cat1'] = np.exp(rr_data.loc[:, 'cat1'])
+        return rr_data
+
+    def load_population_attributable_fraction_data(self, builder: 'Builder'):
+        key_cols = ['sex', 'age_start', 'age_end', 'year_start', 'year_end']
+        exposure_data = get_exposure_data(builder, self.risk).set_index(key_cols)
+        relative_risk_data = self.load_relative_risk_data(builder).set_index(key_cols)
+        mean_rr = (exposure_data * relative_risk_data).sum(axis=1)
+        paf_data = ((mean_rr - 1) / mean_rr).reset_index().rename(columns={0: 'value'})
+        return paf_data
+

--- a/src/vivarium_csu_swissre_cervical_cancer/model_specifications/model_spec.in
+++ b/src/vivarium_csu_swissre_cervical_cancer/model_specifications/model_spec.in
@@ -8,8 +8,6 @@ components:
             - RiskEffect('risk_factor.no_hpv_vaccination', 'sequela.benign_cervical_cancer_to_benign_cervical_cancer_with_hpv.transition_rate')
             - RiskEffect('risk_factor.no_hpv_vaccination', 'sequela.invasive_cervical_cancer_to_invasive_cervical_cancer_with_hpv.transition_rate')
             - RiskEffect('risk_factor.no_hpv_vaccination', 'sequela.benign_cervical_cancer.incidence_rate')
-            - RiskEffect('risk_factor.no_bcc_treatment', 'sequela.benign_cervical_cancer_to_invasive_cervical_cancer.transition_rate')
-            - RiskEffect('risk_factor.no_bcc_treatment', 'sequela.benign_cervical_cancer_with_hpv_to_invasive_cervical_cancer_with_hpv.transition_rate')
 
     vivarium_csu_swissre_cervical_cancer.components:
         - CervicalCancer()
@@ -24,6 +22,9 @@ components:
         - Intervention()
         - HpvVaccineExposure('risk_factor.no_hpv_vaccination')
         - TreatmentExposure('risk_factor.no_bcc_treatment')
+        - LogNormalRiskEffect('risk_factor.no_bcc_treatment', 'sequela.benign_cervical_cancer_to_invasive_cervical_cancer.transition_rate')
+        - LogNormalRiskEffect('risk_factor.no_bcc_treatment', 'sequela.benign_cervical_cancer_with_hpv_to_invasive_cervical_cancer_with_hpv.transition_rate')
+
 
 configuration:
     input_data:
@@ -78,12 +79,12 @@ configuration:
 
     effect_of_no_bcc_treatment_on_benign_cervical_cancer_to_invasive_cervical_cancer:
         transition_rate:
-            mean: 4.55 
-            se: 0.45
+            mean: 4.86
+            se: 0.51
     effect_of_no_bcc_treatment_on_benign_cervical_cancer_with_hpv_to_invasive_cervical_cancer_with_hpv:
         transition_rate:
-            mean: 4.55
-            se: 0.45
+            mean: 4.86
+            se: 0.51
 
     screening_algorithm:
         scenario: 'baseline'


### PR DESCRIPTION
Leveraging LogNormalRiskEffect from the breast cancer sister
repo for use with new guidance on the treatment risk effect from
the RT.

Tested with an interactive run startup and a few time steps.